### PR TITLE
重构监听模块，使TCP支持TProxy，提升代理兼容性

### DIFF
--- a/phantomtcp/dns.go
+++ b/phantomtcp/dns.go
@@ -594,7 +594,7 @@ func (records DNSRecords) BuildResponse(request []byte, qtype int, ttl uint32) [
 	response[2] = 0x81
 	response[3] = 0x80
 
-	if records.Index > 0 {
+	if records.Index > 0 && VirtualAddrPrefix != 255 {
 		switch qtype {
 		case 1:
 			answer := []byte{0xC0, 0x0C, 0x00, 1,

--- a/phantomtcp/phantom.go
+++ b/phantomtcp/phantom.go
@@ -536,9 +536,15 @@ func LoadConfig(filename string) error {
 									if hasCache {
 										r := result.(*DNSRecords)
 										if r.A != nil {
+											if records.A == nil {
+												records.A = new(RecordAddresses)
+											}
 											records.A.Addresses = append(records.A.Addresses, r.A.Addresses...)
 										}
 										if r.AAAA != nil {
+											if records.AAAA == nil {
+												records.AAAA = new(RecordAddresses)
+											}
 											records.AAAA.Addresses = append(records.AAAA.Addresses, r.AAAA.Addresses...)
 										}
 									} else {

--- a/phantomtcp/proxy.go
+++ b/phantomtcp/proxy.go
@@ -16,7 +16,7 @@ func ReadAtLeast() {
 
 }
 
-func SocksProxy(client net.Conn) {
+func SocksProxy(client net.Conn, _ *net.TCPAddr) {
 	defer client.Close()
 
 	var conn net.Conn
@@ -289,7 +289,7 @@ func splitHostPort(hostport string) (host string, port int) {
 	return
 }
 
-func SNIProxy(client net.Conn) {
+func SNIProxy(client net.Conn, addr *net.TCPAddr) {
 	defer client.Close()
 
 	var conn net.Conn
@@ -301,41 +301,27 @@ func SNIProxy(client net.Conn) {
 			return
 		}
 
-		var host string
-		var port int
+		var host = addr.IP.String()
+		var port = addr.Port
 		if b[0] == 0x16 {
 			offset, length := GetSNI(b[:n])
-			if length == 0 {
-				return
+			if length != 0 {
+				host = string(b[offset : offset+length])
 			}
-			host = string(b[offset : offset+length])
-			port = 443
 		} else {
 			offset, length := GetHost(b[:n])
-			if length == 0 {
-				return
-			}
-			host = string(b[offset : offset+length])
-			portstart := strings.Index(host, ":")
-			if portstart == -1 {
-				port = 80
-			} else {
-				port, err = strconv.Atoi(host[portstart+1:])
-				if err != nil {
-					return
+			if length != 0 {
+				host = string(b[offset : offset+length])
+				portStart := strings.Index(host, ":")
+				if portStart != -1 {
+					host = host[:portStart]
 				}
-				host = host[:portstart]
-			}
-			if net.ParseIP(host) != nil {
-				return
 			}
 		}
 
 		server := ConfigLookup(host)
-		if server == nil {
-			return
-		}
-		if server.Hint != 0 {
+
+		if server != nil && (server.Protocol != 0 || server.Hint != 0) {
 			logPrintln(1, "SNI:", host, port, server)
 
 			if b[0] == 0x16 {
@@ -387,7 +373,7 @@ func SNIProxy(client net.Conn) {
 			}
 		} else {
 			host = net.JoinHostPort(host, strconv.Itoa(port))
-			logPrintln(1, host)
+			logPrintln(1, "SNIProxy:", host)
 
 			conn, err = net.Dial("tcp", host)
 			if err != nil {
@@ -413,18 +399,7 @@ func SNIProxy(client net.Conn) {
 	}
 }
 
-func RedirectProxy(client net.Conn) {
-	addr, err := GetOriginalDST(client.(*net.TCPConn))
-	if err != nil {
-		logPrintln(1, err)
-		client.Close()
-		return
-	}
-
-	redirect(client, addr)
-}
-
-func redirect(client net.Conn, addr *net.TCPAddr) {
+func TCPProxy(client net.Conn, addr *net.TCPAddr) {
 	defer client.Close()
 
 	var conn net.Conn
@@ -477,7 +452,7 @@ func redirect(client net.Conn, addr *net.TCPAddr) {
 					server = ConfigLookup(host)
 				}
 
-				logPrintln(1, "Redirect:", client.RemoteAddr(), "->", host, port, server)
+				logPrintln(1, "TCP:", client.RemoteAddr(), "->", host, port, server)
 				if server == nil {
 					return
 				}
@@ -488,7 +463,7 @@ func redirect(client net.Conn, addr *net.TCPAddr) {
 					return
 				}
 			} else {
-				logPrintln(1, "Redirect:", client.RemoteAddr(), "->", host, port, server)
+				logPrintln(1, "TCP:", client.RemoteAddr(), "->", host, port, server)
 				if server.Hint&OPT_HTTP3 != 0 {
 					HttpMove(client, "h3", b[:n])
 					return
@@ -530,7 +505,7 @@ func redirect(client net.Conn, addr *net.TCPAddr) {
 				}
 			}
 		} else if ips != nil {
-			logPrintln(1, "RedirectProxy:", client.RemoteAddr(), "->", addr)
+			logPrintln(1, "TCPProxy:", client.RemoteAddr(), "->", addr)
 			conn, err = net.DialTCP("tcp", nil, addr)
 			if err != nil {
 				logPrintln(1, host, err)

--- a/phantomtcp/tcp.go
+++ b/phantomtcp/tcp.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"math/rand"
 	"net"
 	"os"
@@ -701,4 +702,27 @@ func relay(left, right net.Conn) (int64, int64, error) {
 		err = rs.Err
 	}
 	return n, rs.N, err
+}
+
+func ListenTcpAndServe(listenAddr string, serve func(client net.Conn, dstAddr *net.TCPAddr)) {
+	l, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	for {
+		client, err := l.Accept()
+		if err != nil {
+			log.Panic(err)
+		}
+
+		dstAddr, err := GetOriginalDST(client.(*net.TCPConn))
+		if err != nil {
+			logPrintln(1, err)
+			client.Close()
+			return
+		}
+
+		go serve(client, dstAddr)
+	}
 }

--- a/phantomtcp/tcp_darwin.go
+++ b/phantomtcp/tcp_darwin.go
@@ -58,3 +58,6 @@ func GetOriginalDST(conn *net.TCPConn) (*net.TCPAddr, error) {
 func SendWithOption(conn net.Conn, payload []byte, tos, ttl int) error {
 	return nil
 }
+
+func ListenTcpTProxyAndServe(listenAddr string, serve func(client net.Conn, dstAddr *net.TCPAddr)) {
+}

--- a/phantomtcp/tcp_linux.go
+++ b/phantomtcp/tcp_linux.go
@@ -1,9 +1,12 @@
 package phantomtcp
 
 import (
+	"log"
 	"net"
 	"syscall"
 	"time"
+
+	"github.com/macronut/go-tproxy"
 )
 
 func DialConnInfo(laddr, raddr *net.TCPAddr, server *PhantomInterface, payload []byte) (net.Conn, *ConnectionInfo, error) {
@@ -193,4 +196,26 @@ func SendWithOption(conn net.Conn, payload []byte, tos int, ttl int) error {
 	}
 
 	return nil
+}
+
+func ListenTcpTProxyAndServe(listenAddr string, serve func(client net.Conn, dstAddr *net.TCPAddr)) {
+	listenTCPAddr, _ := net.ResolveTCPAddr("tcp", listenAddr)
+	l, err := tproxy.ListenTCP("tcp", listenTCPAddr)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	for {
+		client, err := l.Accept()
+		if err != nil {
+			log.Panic(err)
+		}
+
+		tcpConn := client.(*tproxy.Conn).TCPConn
+
+		dstAddr := tcpConn.LocalAddr()
+		dstTCPAddr, err := net.ResolveTCPAddr(dstAddr.Network(), dstAddr.String())
+
+		go serve(tcpConn, dstTCPAddr)
+	}
 }

--- a/phantomtcp/tcp_windows.go
+++ b/phantomtcp/tcp_windows.go
@@ -124,3 +124,6 @@ func GetOriginalDST(conn *net.TCPConn) (*net.TCPAddr, error) {
 func SendWithOption(conn net.Conn, payload []byte, tos, ttl int) error {
 	return nil
 }
+
+func ListenTcpTProxyAndServe(listenAddr string, serve func(client net.Conn, dstAddr *net.TCPAddr)) {
+}

--- a/phantomtcp/wireguard.go
+++ b/phantomtcp/wireguard.go
@@ -46,7 +46,7 @@ func WireGuardServer(service ServiceConfig) {
 			}
 			switch addr := client.LocalAddr().(type) {
 			case *net.TCPAddr:
-				go redirect(client, &net.TCPAddr{IP: addr.IP.To4(), Port: addr.Port})
+				go TCPProxy(client, &net.TCPAddr{IP: addr.IP.To4(), Port: addr.Port})
 			}
 		}
 	}


### PR DESCRIPTION
close #40

修复了conf文件别名写法导致的错误
改动了DNS服务，如果用户设置了不合法的vaddrprefix（比如0），返回真实地址，我觉得这里是否需要虚拟地址应该交给用户来决定
改动了一下监听写法，使TCP代理支持TProxy
修改了SNIProxy，使其在无法得到域名（PhantomInterface）的情况下可以后退成正常流量
预计接下来会再对QUIC For TProxy和Udp For TProxy改动，使其可以后退

- [x] Tcp
- [ ] Udp
- [x] SNI Tcp
- [ ] SNI Udp（QUIC）