### PR TITLE
fix GetLocalAddr()

### DIFF
--- a/phantomtcp/tcp.go
+++ b/phantomtcp/tcp.go
@@ -123,7 +123,7 @@ func GetLocalAddr(name string, ipv6 bool) (*net.TCPAddr, error) {
 			var laddr *net.TCPAddr
 			ip4 := localAddr.IP.To4()
 			if ipv6 {
-				if ip4 != nil || localAddr.IP[0] == 0xfe {
+				if ip4 != nil || localAddr.IP.IsPrivate() {
 					continue
 				}
 				ip := make([]byte, 16)


### PR DESCRIPTION
原先不会跳过像 `fd82:8859:a80d::e70/128` 这样的地址导致ipv6连不上网