### PR TITLE
Fix wrong pface

### DIFF
--- a/phantomtcp/proxy.go
+++ b/phantomtcp/proxy.go
@@ -310,7 +310,7 @@ func tcp_redirect(client net.Conn, addr *net.TCPAddr, domain string, header []by
 				if length > 0 {
 					_domain := string(header[offset : offset+length])
 					if domain != _domain {
-						pface = DefaultProfile.GetInterface(domain)
+						pface = DefaultProfile.GetInterface(_domain)
 						if pface == nil {
 							return
 						}


### PR DESCRIPTION
I find my ipv6 hint not working sometimes, debug and found [this](https://github.com/macronut/phantomsocks/blob/7cca681a2b901025a5eeb50bd6cbfb27426d0021/phantomtcp/proxy.go#L313C1-L313C1), it's this intentional or just mistaken?