### PR TITLE
Parse HTTPS record response

### DIFF
--- a/phantomtcp/dns.go
+++ b/phantomtcp/dns.go
@@ -1385,6 +1385,13 @@ func NSRequest(request []byte, cache bool) (uint32, []byte) {
 			return 0, records.BuildResponse(request, qtype, 0)
 		}
 		logPrintln(3, "response:", name, qtype, records.IPv6Hint.Addresses)
+	case 65:
+		records.GetAnswers(response, options)
+		if records.ALPN == 0 {
+			logPrintln(4, "request", name, qtype, "no answer")
+			return 0, records.BuildResponse(request, qtype, 0)
+		}
+		logPrintln(3, "response:", name, qtype, records.ALPN)
 	default:
 		return 0, response
 	}


### PR DESCRIPTION
```go
	default:
		return 0, response
	}
```

At this point, type65 would be treated as `default` and the original response from upstream get returned ahead of the following code,

```go
	if UseVaddr && (records.Index == 0) {
		records.Index = AddDNSLie(name, outbound)
```

effectively bypassing Vaddr.

The prior fix #82 added unnecessary complexity, I should utilize `GetAnswers` to parse HTTPS record response correctly, that would also prevent 65 being returned too early.