### PR TITLE
Drop A or AAAA requests more safely

### DIFF
--- a/phantomtcp/dns.go
+++ b/phantomtcp/dns.go
@@ -1317,11 +1317,18 @@ func NSRequest(request []byte, cache bool) (uint32, []byte) {
 	_request := request
 	_qtype := uint16(qtype)
 	if u.RawQuery != "" {
-		if records.ALPN&HINT_IPV4 != 0 && qtype == 28 {
-			return records.Index, records.BuildResponse(request, qtype, 0)
-		}
-		if records.ALPN&HINT_IPV6 != 0 && qtype == 1 {
-			return records.Index, records.BuildResponse(request, qtype, 0)
+		if UseVaddr {
+			if records.ALPN&HINT_IPV4 != 0 && qtype == 28 {
+				_qtype = 1
+			} else if records.ALPN&HINT_IPV6 != 0 && qtype == 1 {
+				_qtype = 28
+			}
+		} else {
+			if records.ALPN&HINT_IPV4 != 0 && qtype == 28 {
+				return records.Index, records.BuildResponse(request, qtype, 0)
+			} else if records.ALPN&HINT_IPV6 != 0 && qtype == 1 {
+				return records.Index, records.BuildResponse(request, qtype, 0)
+			}
 		}
 
 		options = ParseOptions(u.RawQuery)


### PR DESCRIPTION
Currently, if hint contains `ipv6` and does not contain `fakeip`, all request type including `A`, `NS` or `HTTPS` would be rewritten to `AAAA` and the response appended to records.IPv6Hint.

1st request:

```
gfw.report.        0    IN    HTTPS    1 . ipv6hint=2606:4700:3036::ac43:8456,2606:4700:3037::6815:cbd
```
2nd request:
```
gfw.report.        0    IN    HTTPS    1 . ipv6hint=2606:4700:3036::ac43:8456,2606:4700:3037::6815:cbd,2606:4700:3037::6815:cbd,2606:4700:3036::ac43:8456
```
3rd request:
```
gfw.report.        0    IN    HTTPS    1 . ipv6hint=2606:4700:3036::ac43:8456,2606:4700:3037::6815:cbd,2606:4700:3037::6815:cbd,2606:4700:3036::ac43:8456,2606:4700:3036::ac43:8456,2606:4700:3037::6815:cbd
```

It should, instead of rewriting all request types, only drop `A` or `AAAA` request, like it does for ServerOptions.