### PR TITLE
Prefer IP rule over domain rule when SNI has no explicit match

### DIFF
--- a/phantomtcp/phantom.go
+++ b/phantomtcp/phantom.go
@@ -190,27 +190,6 @@ func (profile *PhantomProfile) GetOutbound(name string) (*Outbound, int) {
 	return DefaultOutbound, 0
 }
 
-func (profile *PhantomProfile) HasDomainRule(name string) bool {
-	if _, ok := profile.DomainMap[name]; ok {
-		return true
-	}
-
-	offset := 0
-	for i := 0; i < SubdomainDepth; i++ {
-		off := strings.Index(name[offset:], ".")
-		if off == -1 {
-			break
-		}
-		offset += off
-		if _, ok := profile.DomainMap[name[offset:]]; ok {
-			return true
-		}
-		offset++
-	}
-
-	return false
-}
-
 func (profile *PhantomProfile) GetOutboundByIP(ip net.IP) *Outbound {
 	ip4 := ip.To4()
 	if ip4 != nil {

--- a/phantomtcp/phantom.go
+++ b/phantomtcp/phantom.go
@@ -190,6 +190,27 @@ func (profile *PhantomProfile) GetOutbound(name string) (*Outbound, int) {
 	return DefaultOutbound, 0
 }
 
+func (profile *PhantomProfile) HasDomainRule(name string) bool {
+	if _, ok := profile.DomainMap[name]; ok {
+		return true
+	}
+
+	offset := 0
+	for i := 0; i < SubdomainDepth; i++ {
+		off := strings.Index(name[offset:], ".")
+		if off == -1 {
+			break
+		}
+		offset += off
+		if _, ok := profile.DomainMap[name[offset:]]; ok {
+			return true
+		}
+		offset++
+	}
+
+	return false
+}
+
 func (profile *PhantomProfile) GetOutboundByIP(ip net.IP) *Outbound {
 	ip4 := ip.To4()
 	if ip4 != nil {

--- a/phantomtcp/proxy.go
+++ b/phantomtcp/proxy.go
@@ -218,7 +218,13 @@ func tcp_redirect(client net.Conn, addr *net.TCPAddr, domain string, header []by
 					if domain != sni {
 						if ech {
 							logPrintln(2, domain, "tls hello with ECH", sni)
-						} else {
+						} else if DefaultProfile.HasDomainRule(sni) {
+							outbound, _ = DefaultProfile.GetOutbound(sni)
+							if outbound == nil {
+								return
+							}
+							domain = sni
+						} else if addr.IP == nil {
 							outbound, _ = DefaultProfile.GetOutbound(sni)
 							if outbound == nil {
 								return

--- a/phantomtcp/proxy.go
+++ b/phantomtcp/proxy.go
@@ -218,12 +218,6 @@ func tcp_redirect(client net.Conn, addr *net.TCPAddr, domain string, header []by
 					if domain != sni {
 						if ech {
 							logPrintln(2, domain, "tls hello with ECH", sni)
-						} else if DefaultProfile.HasDomainRule(sni) {
-							outbound, _ = DefaultProfile.GetOutbound(sni)
-							if outbound == nil {
-								return
-							}
-							domain = sni
 						} else if addr.IP == nil {
 							outbound, _ = DefaultProfile.GetOutbound(sni)
 							if outbound == nil {


### PR DESCRIPTION
TProxy/redirect IP-based inbound previously let any TLS SNI sniff override the IP-matched outbound, collapsing to DefaultOutbound (or disconnecting) when the SNI had no explicit domain rule. Domain rules now take priority when they explicitly match; otherwise IP-inbound connections fall back to the outbound chosen by GetOutboundByIP instead of being overridden.